### PR TITLE
backblast and projectile type fixes

### DIFF
--- a/zscript/proj_hopper_backblasts.zsc
+++ b/zscript/proj_hopper_backblasts.zsc
@@ -65,7 +65,7 @@ class HD_HopperBackblast:manjuice
 	states
 	{
 	spawn:
-		MANF A 1 NODELAY
+		MANF A 1
 		{
 			for(int i = 0; i < random(6,7); i++)
 			{

--- a/zscript/wep_hdhopper.zsc
+++ b/zscript/wep_hdhopper.zsc
@@ -37,6 +37,8 @@ class HDHopper:HDWeapon
 action void A_BackBlast()
 	{	
 		vector3 positionoffset = pos+gunpos((0,0,-getdefaultbytype("GyroGrenade").height*0.6));
+		positionoffset += (cos(angle-180) * 30, sin(angle-180) * 30,-sin(pitch)*-3);
+		
 		let blst=hd_hopperbackblast(spawn("HD_HopperBackblast",positionoffset,
 			ALLOW_REPLACE)
 		);
@@ -52,6 +54,8 @@ action void A_BackBlast()
 action void A_HeatBackBlast()
 	{
 		vector3 positionoffset = pos+gunpos((0,0,-getdefaultbytype("HDHEAT").height*0.6));
+		positionoffset += (cos(angle-180) * 30, sin(angle-180) * 30,-sin(pitch)*-3);
+		
 		let blst=hd_hopperheatbackblast(spawn("HD_HopperheatBackblast",positionoffset,
 			ALLOW_REPLACE)
 		);

--- a/zscript/wep_hdhopper.zsc
+++ b/zscript/wep_hdhopper.zsc
@@ -36,23 +36,8 @@ class HDHopper:HDWeapon
 	
 action void A_BackBlast()
 	{	
-		vector3 positionoffset;
-		vector3 gpos=pos+gunpos((0,0,-getdefaultbytype("GyroGrenade").height*0.6));
-		let ggg=gyrogrenade(spawn("GyroGrenade",gpos,ALLOW_REPLACE));
-
-		let hdp=hdplayerpawn(self);
-		if(hdp){
-			ggg.angle=hdp.gunangle;
-			ggg.pitch=hdp.gunpitch-2;
-		}else{
-			ggg.angle=angle;
-			ggg.pitch=pitch-2;
-		}
-
-		ggg.target=self;ggg.master=self;
-		ggg.primed=false;
-
-		let blst=hd_hopperbackblast(spawn("HD_HopperBackblast",pos+positionoffset,
+		vector3 positionoffset = pos+gunpos((0,0,-getdefaultbytype("GyroGrenade").height*0.6));
+		let blst=hd_hopperbackblast(spawn("HD_HopperBackblast",positionoffset,
 			ALLOW_REPLACE)
 		);
 		blst.angle=angle-180;
@@ -66,23 +51,8 @@ action void A_BackBlast()
 	
 action void A_HeatBackBlast()
 	{
-		vector3 positionoffset;
-		vector3 gpos=pos+gunpos((0,0,-getdefaultbytype("GyroGrenade").height*0.6));
-		let ggg=gyrogrenade(spawn("GyroGrenade",gpos,ALLOW_REPLACE));
-
-		let hdp=hdplayerpawn(self);
-		if(hdp){
-			ggg.angle=hdp.gunangle;
-			ggg.pitch=hdp.gunpitch-2;
-		}else{
-			ggg.angle=angle;
-			ggg.pitch=pitch-2;
-		}
-
-		ggg.target=self;ggg.master=self;
-		ggg.primed=false;
-
-		let blst=hd_hopperheatbackblast(spawn("HD_HopperheatBackblast",pos+positionoffset,
+		vector3 positionoffset = pos+gunpos((0,0,-getdefaultbytype("HDHEAT").height*0.6));
+		let blst=hd_hopperheatbackblast(spawn("HD_HopperheatBackblast",positionoffset,
 			ALLOW_REPLACE)
 		);
 		blst.angle=angle-180;
@@ -324,10 +294,6 @@ action void A_HeatBackBlast()
 	reallyshoot:
 		HPPR B 2
 		{
-				//int hplr=invoker.weaponstatus[HOPPF_STATUS];
-				//if(hplr<1){
-				//setweaponstate("reload");
-				//return;
 		A_GunFlash();
 		gyrogrenade rkt;
 		class<actor> rrr;
@@ -345,6 +311,24 @@ action void A_HeatBackBlast()
 			rrr="GyroGrenade";
 			A_BackBlast();
 		}
+
+
+		vector3 gpos=pos+gunpos((0,0,-getdefaultbytype(rrr).height*0.6));
+		rkt = gyrogrenade(spawn(rrr,gpos,ALLOW_REPLACE));
+
+		let hdp=hdplayerpawn(self);
+		if(hdp)
+		{
+			rkt.angle=hdp.gunangle;
+			rkt.pitch=hdp.gunpitch-2;
+		}else
+		{
+			rkt.angle=angle;
+			rkt.pitch=pitch-2;
+		}
+
+		rkt.target=self;rkt.master=self;
+		rkt.primed=false;
 
 		A_ZoomRecoil(0.7);
 		if(gunbraced())
@@ -367,29 +351,9 @@ action void A_HeatBackBlast()
 				A_ChangeVelocity(cos(pitch)*-3,0,sin(pitch)*3,CVF_RELATIVE);
 				if(self is "hdplayerpawn")hdplayerpawn(self).stunned+=10;
 			}
-		
-		vector3 gpos=pos+gunpos((0,0,-getdefaultbytype("GyroGrenade").height*0.6));
-		let ggg=gyrogrenade(spawn("GyroGrenade",gpos,ALLOW_REPLACE));
-
-		let hdp=hdplayerpawn(self);
-		if(hdp){
-			ggg.angle=hdp.gunangle;
-			ggg.pitch=hdp.gunpitch-2;
-		}else{
-			ggg.angle=angle;
-			ggg.pitch=pitch-2;
-		}
-
-		ggg.target=self;ggg.master=self;
-		ggg.primed=false;
-		
 		invoker.weaponstatus[RLS_SMOKE]+=50;
-		/*
-		rkt.angle=angle;rkt.pitch=pitch;rkt.target=self;rkt.master=self;
-		rkt.primed=false;
-		rkt.isrocket=true;
-		*/
 		invoker.weaponstatus[HOPPF_LOADED_RG]=0;
+		
 		A_StartSound("weapons/rockignite",CHAN_WEAPON,CHANF_OVERLAP);
 		A_StartSound("weapons/rockboom",CHAN_WEAPON,CHANF_OVERLAP);
 		}

--- a/zscript/wep_hdhopper.zsc
+++ b/zscript/wep_hdhopper.zsc
@@ -315,7 +315,6 @@ action void A_HeatBackBlast()
 
 		vector3 gpos=pos+gunpos((0,0,-getdefaultbytype(rrr).height*0.6));
 		rkt = gyrogrenade(spawn(rrr,gpos,ALLOW_REPLACE));
-
 		let hdp=hdplayerpawn(self);
 		if(hdp)
 		{
@@ -326,9 +325,9 @@ action void A_HeatBackBlast()
 			rkt.angle=angle;
 			rkt.pitch=pitch-2;
 		}
-
 		rkt.target=self;rkt.master=self;
 		rkt.primed=false;
+		rkt.isrocket=true;
 
 		A_ZoomRecoil(0.7);
 		if(gunbraced())

--- a/zscript/wep_hdhopper.zsc
+++ b/zscript/wep_hdhopper.zsc
@@ -316,14 +316,12 @@ action void A_HeatBackBlast()
 		vector3 gpos=pos+gunpos((0,0,-getdefaultbytype(rrr).height*0.6));
 		rkt = gyrogrenade(spawn(rrr,gpos,ALLOW_REPLACE));
 		let hdp=hdplayerpawn(self);
-		if(hdp)
-		{
+		if(hdp){
 			rkt.angle=hdp.gunangle;
-			rkt.pitch=hdp.gunpitch-2;
-		}else
-		{
+			rkt.pitch=hdp.gunpitch;
+		}else{
 			rkt.angle=angle;
-			rkt.pitch=pitch-2;
+			rkt.pitch=pitch;
 		}
 		rkt.target=self;rkt.master=self;
 		rkt.primed=false;


### PR DESCRIPTION
Several interconnected fixes to how projectile picking and backblast location choosing works. Both should now be 1:1, and spawn their respective projectiles. 